### PR TITLE
Use latest HfApi.create_repo() parameter

### DIFF
--- a/HuggingPics.ipynb
+++ b/HuggingPics.ipynb
@@ -1,10 +1,26 @@
 {
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "include_colab_link": true
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    },
+    "accelerator": "GPU"
+  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "colab_type": "text",
-        "id": "view-in-github"
+        "id": "view-in-github",
+        "colab_type": "text"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/nateraw/huggingpics/blob/main/HuggingPics.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -23,26 +39,24 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "XVyU3ScYZ3Hc"
       },
-      "outputs": [],
       "source": [
         "%%capture\n",
         "\n",
         "! pip install transformers pytorch-lightning --quiet\n",
         "! sudo apt -qq install git-lfs\n",
         "! git config --global credential.helper store"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "ihFempth1zK0"
       },
-      "outputs": [],
       "source": [
         "import requests\n",
         "import math\n",
@@ -60,7 +74,9 @@
         "from torchmetrics import Accuracy\n",
         "from torchvision.datasets import ImageFolder\n",
         "from transformers import ViTFeatureExtractor, ViTForImageClassification"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -90,12 +106,10 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "cellView": "form",
-        "id": "JGyijnL08Cge"
+        "id": "JGyijnL08Cge",
+        "cellView": "form"
       },
-      "outputs": [],
       "source": [
         "term_1 = \"samoyed\" #@param {type:\"string\"}\n",
         "term_2 = \"shiba inu\" #@param {type:\"string\"}\n",
@@ -112,7 +126,9 @@
         "])\n",
         "\n",
         "search_terms = [x for x in search_terms if x.strip() != '']"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -129,11 +145,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "jJEH5b3rsdId"
       },
-      "outputs": [],
       "source": [
         "SEARCH_URL = \"https://huggingface.co/api/experimental/images/search\"\n",
         "\n",
@@ -164,15 +178,15 @@
         "def urls_to_image_folder(urls, save_directory):\n",
         "    for i, image in enumerate(gen_images_from_urls(urls)):\n",
         "        image.save(save_directory / f'{i}.jpg')"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "PKBb34N9qnNS"
       },
-      "outputs": [],
       "source": [
         "data_dir = Path('images')\n",
         "\n",
@@ -185,7 +199,9 @@
         "    urls = get_image_urls_by_term(search_term)\n",
         "    print(f\"Saving images of {search_term} to {str(search_term_dir)}...\")\n",
         "    urls_to_image_folder(urls, search_term_dir)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -198,18 +214,18 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "U4vCcep26Em6"
       },
-      "outputs": [],
       "source": [
         "ds = ImageFolder(data_dir)\n",
         "indices = torch.randperm(len(ds)).tolist()\n",
         "n_val = math.floor(len(indices) * .15)\n",
         "train_ds = torch.utils.data.Subset(ds, indices[:-n_val])\n",
         "val_ds = torch.utils.data.Subset(ds, indices[-n_val:])"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -228,11 +244,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "wbzsRQRe6iY5"
       },
-      "outputs": [],
       "source": [
         "plt.figure(figsize=(20,10))\n",
         "num_examples_per_class = 5\n",
@@ -258,7 +272,9 @@
         "\n",
         "            if image_idx + 1 == num_examples_per_class:\n",
         "                break"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -273,11 +289,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "mh0yxRKDGDd5"
       },
-      "outputs": [],
       "source": [
         "label2id = {}\n",
         "id2label = {}\n",
@@ -285,7 +299,9 @@
         "for i, class_name in enumerate(ds.classes):\n",
         "    label2id[class_name] = str(i)\n",
         "    id2label[str(i)] = class_name"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -300,11 +316,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "D2n0Mf1u1ymf"
       },
-      "outputs": [],
       "source": [
         "class ImageClassificationCollator:\n",
         "    def __init__(self, feature_extractor):\n",
@@ -314,7 +328,9 @@
         "        encodings = self.feature_extractor([x[0] for x in batch], return_tensors='pt')\n",
         "        encodings['labels'] = torch.tensor([x[1] for x in batch], dtype=torch.long)\n",
         "        return encodings "
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -327,11 +343,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "YovQELKD4Bu8"
       },
-      "outputs": [],
       "source": [
         "feature_extractor = ViTFeatureExtractor.from_pretrained('google/vit-base-patch16-224-in21k')\n",
         "model = ViTForImageClassification.from_pretrained(\n",
@@ -343,7 +357,9 @@
         "collator = ImageClassificationCollator(feature_extractor)\n",
         "train_loader = DataLoader(train_ds, batch_size=8, collate_fn=collator, num_workers=2, shuffle=True)\n",
         "val_loader = DataLoader(val_ds, batch_size=8, collate_fn=collator, num_workers=2)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -358,11 +374,9 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "UIIRpEzW4LFo"
       },
-      "outputs": [],
       "source": [
         "class Classifier(pl.LightningModule):\n",
         "\n",
@@ -390,21 +404,23 @@
         "\n",
         "    def configure_optimizers(self):\n",
         "        return torch.optim.Adam(self.parameters(), lr=self.hparams.lr)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "wTWYA1rf3Heg"
       },
-      "outputs": [],
       "source": [
         "pl.seed_everything(42)\n",
         "classifier = Classifier(model, lr=2e-5)\n",
         "trainer = pl.Trainer(accelerator='gpu', devices=1, precision=16, max_epochs=4)\n",
         "trainer.fit(classifier, train_loader, val_loader)"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -417,17 +433,17 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
         "id": "tDfUUwH73LSq"
       },
-      "outputs": [],
       "source": [
         "val_batch = next(iter(val_loader))\n",
         "outputs = model(**val_batch)\n",
         "print('Preds: ', outputs.logits.softmax(1).argmax(1))\n",
         "print('Labels:', val_batch['labels'])"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "markdown",
@@ -444,23 +460,21 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "source": [
+        "notebook_login()"
+      ],
       "metadata": {
         "id": "d1t_A7PkNRiY"
       },
-      "outputs": [],
-      "source": [
-        "notebook_login()"
-      ]
+      "execution_count": null,
+      "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": null,
       "metadata": {
-        "cellView": "form",
-        "id": "t58j9AN-iELM"
+        "id": "t58j9AN-iELM",
+        "cellView": "form"
       },
-      "outputs": [],
       "source": [
         "model_id = \"rare-puppers\" #@param {type:\"string\"}\n",
         "\n",
@@ -486,7 +500,7 @@
         "    raise RuntimeError(\"You must log in to push to hub! Run notebook_login() in the cell above.\")\n",
         "\n",
         "hf_username = HfApi().whoami()['name']\n",
-        "model_url = HfApi().create_repo(token=token, repo_id=model_id, exist_ok=True)\n",
+        "model_url = HfApi().create_repo(token=token, name=model_id, exist_ok=True)\n",
         "model_repo = Repository(\"./model\", clone_from=model_url, use_auth_token=token, git_email=f\"{hf_username}@users.noreply.huggingface.co\", git_user=hf_username)\n",
         "model.save_pretrained(model_repo.local_dir)\n",
         "feature_extractor.save_pretrained(model_repo.local_dir)\n",
@@ -555,23 +569,9 @@
         "\n",
         "print(\"Check out your model at:\")\n",
         "print(f\"https://huggingface.co/{hf_username}/{model_id}\")"
-      ]
+      ],
+      "execution_count": null,
+      "outputs": []
     }
-  ],
-  "metadata": {
-    "accelerator": "GPU",
-    "colab": {
-      "include_colab_link": true,
-      "provenance": []
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "name": "python"
-    }
-  },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  ]
 }

--- a/HuggingPics.ipynb
+++ b/HuggingPics.ipynb
@@ -1,26 +1,10 @@
 {
-  "nbformat": 4,
-  "nbformat_minor": 0,
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "include_colab_link": true
-    },
-    "kernelspec": {
-      "name": "python3",
-      "display_name": "Python 3"
-    },
-    "language_info": {
-      "name": "python"
-    },
-    "accelerator": "GPU"
-  },
   "cells": [
     {
       "cell_type": "markdown",
       "metadata": {
-        "id": "view-in-github",
-        "colab_type": "text"
+        "colab_type": "text",
+        "id": "view-in-github"
       },
       "source": [
         "<a href=\"https://colab.research.google.com/github/nateraw/huggingpics/blob/main/HuggingPics.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
@@ -39,24 +23,26 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "XVyU3ScYZ3Hc"
       },
+      "outputs": [],
       "source": [
         "%%capture\n",
         "\n",
         "! pip install transformers pytorch-lightning --quiet\n",
         "! sudo apt -qq install git-lfs\n",
         "! git config --global credential.helper store"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "ihFempth1zK0"
       },
+      "outputs": [],
       "source": [
         "import requests\n",
         "import math\n",
@@ -74,9 +60,7 @@
         "from torchmetrics import Accuracy\n",
         "from torchvision.datasets import ImageFolder\n",
         "from transformers import ViTFeatureExtractor, ViTForImageClassification"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -106,10 +90,12 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "JGyijnL08Cge",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "JGyijnL08Cge"
       },
+      "outputs": [],
       "source": [
         "term_1 = \"samoyed\" #@param {type:\"string\"}\n",
         "term_2 = \"shiba inu\" #@param {type:\"string\"}\n",
@@ -126,9 +112,7 @@
         "])\n",
         "\n",
         "search_terms = [x for x in search_terms if x.strip() != '']"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -145,9 +129,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "jJEH5b3rsdId"
       },
+      "outputs": [],
       "source": [
         "SEARCH_URL = \"https://huggingface.co/api/experimental/images/search\"\n",
         "\n",
@@ -178,15 +164,15 @@
         "def urls_to_image_folder(urls, save_directory):\n",
         "    for i, image in enumerate(gen_images_from_urls(urls)):\n",
         "        image.save(save_directory / f'{i}.jpg')"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "PKBb34N9qnNS"
       },
+      "outputs": [],
       "source": [
         "data_dir = Path('images')\n",
         "\n",
@@ -199,9 +185,7 @@
         "    urls = get_image_urls_by_term(search_term)\n",
         "    print(f\"Saving images of {search_term} to {str(search_term_dir)}...\")\n",
         "    urls_to_image_folder(urls, search_term_dir)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -214,18 +198,18 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "U4vCcep26Em6"
       },
+      "outputs": [],
       "source": [
         "ds = ImageFolder(data_dir)\n",
         "indices = torch.randperm(len(ds)).tolist()\n",
         "n_val = math.floor(len(indices) * .15)\n",
         "train_ds = torch.utils.data.Subset(ds, indices[:-n_val])\n",
         "val_ds = torch.utils.data.Subset(ds, indices[-n_val:])"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -244,9 +228,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "wbzsRQRe6iY5"
       },
+      "outputs": [],
       "source": [
         "plt.figure(figsize=(20,10))\n",
         "num_examples_per_class = 5\n",
@@ -272,9 +258,7 @@
         "\n",
         "            if image_idx + 1 == num_examples_per_class:\n",
         "                break"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -289,9 +273,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "mh0yxRKDGDd5"
       },
+      "outputs": [],
       "source": [
         "label2id = {}\n",
         "id2label = {}\n",
@@ -299,9 +285,7 @@
         "for i, class_name in enumerate(ds.classes):\n",
         "    label2id[class_name] = str(i)\n",
         "    id2label[str(i)] = class_name"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -316,9 +300,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "D2n0Mf1u1ymf"
       },
+      "outputs": [],
       "source": [
         "class ImageClassificationCollator:\n",
         "    def __init__(self, feature_extractor):\n",
@@ -328,9 +314,7 @@
         "        encodings = self.feature_extractor([x[0] for x in batch], return_tensors='pt')\n",
         "        encodings['labels'] = torch.tensor([x[1] for x in batch], dtype=torch.long)\n",
         "        return encodings "
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -343,9 +327,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "YovQELKD4Bu8"
       },
+      "outputs": [],
       "source": [
         "feature_extractor = ViTFeatureExtractor.from_pretrained('google/vit-base-patch16-224-in21k')\n",
         "model = ViTForImageClassification.from_pretrained(\n",
@@ -357,9 +343,7 @@
         "collator = ImageClassificationCollator(feature_extractor)\n",
         "train_loader = DataLoader(train_ds, batch_size=8, collate_fn=collator, num_workers=2, shuffle=True)\n",
         "val_loader = DataLoader(val_ds, batch_size=8, collate_fn=collator, num_workers=2)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -374,9 +358,11 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "UIIRpEzW4LFo"
       },
+      "outputs": [],
       "source": [
         "class Classifier(pl.LightningModule):\n",
         "\n",
@@ -404,23 +390,21 @@
         "\n",
         "    def configure_optimizers(self):\n",
         "        return torch.optim.Adam(self.parameters(), lr=self.hparams.lr)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "wTWYA1rf3Heg"
       },
+      "outputs": [],
       "source": [
         "pl.seed_everything(42)\n",
         "classifier = Classifier(model, lr=2e-5)\n",
         "trainer = pl.Trainer(accelerator='gpu', devices=1, precision=16, max_epochs=4)\n",
         "trainer.fit(classifier, train_loader, val_loader)"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -433,17 +417,17 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
         "id": "tDfUUwH73LSq"
       },
+      "outputs": [],
       "source": [
         "val_batch = next(iter(val_loader))\n",
         "outputs = model(**val_batch)\n",
         "print('Preds: ', outputs.logits.softmax(1).argmax(1))\n",
         "print('Labels:', val_batch['labels'])"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
@@ -460,21 +444,23 @@
     },
     {
       "cell_type": "code",
-      "source": [
-        "notebook_login()"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "d1t_A7PkNRiY"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "notebook_login()"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {
-        "id": "t58j9AN-iELM",
-        "cellView": "form"
+        "cellView": "form",
+        "id": "t58j9AN-iELM"
       },
+      "outputs": [],
       "source": [
         "model_id = \"rare-puppers\" #@param {type:\"string\"}\n",
         "\n",
@@ -500,7 +486,7 @@
         "    raise RuntimeError(\"You must log in to push to hub! Run notebook_login() in the cell above.\")\n",
         "\n",
         "hf_username = HfApi().whoami()['name']\n",
-        "model_url = HfApi().create_repo(token=token, name=model_id, exist_ok=True)\n",
+        "model_url = HfApi().create_repo(token=token, repo_id=model_id, exist_ok=True)\n",
         "model_repo = Repository(\"./model\", clone_from=model_url, use_auth_token=token, git_email=f\"{hf_username}@users.noreply.huggingface.co\", git_user=hf_username)\n",
         "model.save_pretrained(model_repo.local_dir)\n",
         "feature_extractor.save_pretrained(model_repo.local_dir)\n",
@@ -569,9 +555,23 @@
         "\n",
         "print(\"Check out your model at:\")\n",
         "print(f\"https://huggingface.co/{hf_username}/{model_id}\")"
-      ],
-      "execution_count": null,
-      "outputs": []
+      ]
     }
-  ]
+  ],
+  "metadata": {
+    "accelerator": "GPU",
+    "colab": {
+      "include_colab_link": true,
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/HuggingPics.ipynb
+++ b/HuggingPics.ipynb
@@ -500,7 +500,7 @@
         "    raise RuntimeError(\"You must log in to push to hub! Run notebook_login() in the cell above.\")\n",
         "\n",
         "hf_username = HfApi().whoami()['name']\n",
-        "model_url = HfApi().create_repo(token=token, name=model_id, exist_ok=True)\n",
+        "model_url = HfApi().create_repo(token=token, repo_id=model_id, exist_ok=True)\n",
         "model_repo = Repository(\"./model\", clone_from=model_url, use_auth_token=token, git_email=f\"{hf_username}@users.noreply.huggingface.co\", git_user=hf_username)\n",
         "model.save_pretrained(model_repo.local_dir)\n",
         "feature_extractor.save_pretrained(model_repo.local_dir)\n",


### PR DESCRIPTION
Hi, it seems like HfApi.create_repo() parameters are updated and no longer treat 'name' as valid parameter. Made this PR to solve error when pushing model to huggingface hub

`TypeError: create_repo() got an unexpected keyword argument 'name'`

<img width="1436" alt="Screen Shot 2022-12-13 at 22 24 20" src="https://user-images.githubusercontent.com/52346702/207383498-5d6f19f4-ed4e-43e4-9642-aaf1ca827c8d.png">

<img width="937" alt="Screen Shot 2022-12-13 at 23 14 43" src="https://user-images.githubusercontent.com/52346702/207385842-e2682ff2-b3d5-4578-a561-1e3b8cfddbd1.png">
